### PR TITLE
Fixes Firefox extension compatibility by using Manifest V2

### DIFF
--- a/public/manifest.firefox.v2.json
+++ b/public/manifest.firefox.v2.json
@@ -21,7 +21,7 @@
     "https://web.telegram.org/*"
   ],
   "background": {
-    "scripts": ["background/background.js"],
+    "scripts": ["background/background-firefox.js"],
     "persistent": false
   },
   "browser_action": {


### PR DESCRIPTION
- Removes 'type: module' from manifest.firefox.json background configuration
- Updates manifest.firefox.v2.json to use correct background-firefox.js script
- Firefox Manifest V3 support is experimental and broken (service_worker not supported)
- Firefox Manifest V2 is stable and fully supported with scripts array