### PR TITLE
Fix cross-browser extension compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+safari-build/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && node scripts/post-build.js",
     "build:chrome": "vite build && node scripts/post-build.js chrome",
     "build:firefox": "vite build && node scripts/post-build.js firefox",
+    "build:safari": "vite build && node scripts/post-build.js safari",
     "build:all": "pnpm build:chrome && pnpm build:firefox",
     "preview": "vite preview",
     "test": "vitest",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,14 +1,12 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "DefNotPromo",
   "version": "1.0.0",
   "description": "AI-powered social media self-promotion assistant with analytics",
   "permissions": [
     "storage",
     "activeTab",
-    "scripting"
-  ],
-  "host_permissions": [
+    "tabs",
     "https://twitter.com/*",
     "https://x.com/*",
     "https://www.linkedin.com/*",
@@ -23,9 +21,10 @@
     "https://web.telegram.org/*"
   ],
   "background": {
-    "scripts": ["background/background-firefox.js"]
+    "scripts": ["background/background-firefox.js"],
+    "persistent": false
   },
-  "action": {
+  "browser_action": {
     "default_popup": "src/popup/index.html",
     "default_icon": {
       "16": "icons/icon-16.svg",
@@ -101,16 +100,11 @@
       "run_at": "document_idle"
     }
   ],
-  "web_accessible_resources": [
-    {
-      "resources": ["assets/*", "icons/*"],
-      "matches": ["<all_urls>"]
-    }
-  ],
+  "web_accessible_resources": ["assets/*", "icons/*"],
   "browser_specific_settings": {
     "gecko": {
       "id": "defnotpromo@profullstack.com",
-      "strict_min_version": "109.0"
+      "strict_min_version": "57.0"
     }
   }
 }

--- a/public/manifest.safari.json
+++ b/public/manifest.safari.json
@@ -1,12 +1,15 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "DefNotPromo",
   "version": "1.0.0",
   "description": "AI-powered social media self-promotion assistant with analytics",
   "permissions": [
     "storage",
     "activeTab",
-    "tabs",
+    "scripting",
+    "tabs"
+  ],
+  "host_permissions": [
     "https://twitter.com/*",
     "https://x.com/*",
     "https://www.linkedin.com/*",
@@ -21,32 +24,22 @@
     "https://web.telegram.org/*"
   ],
   "background": {
-    "scripts": ["background/background-firefox.js"],
-    "persistent": false
+    "service_worker": "background/service-worker.js"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "src/popup/index.html",
     "default_icon": {
-      "16": "icons/icon-16.svg",
-      "32": "icons/icon-32.svg",
-      "48": "icons/icon-48.svg",
-      "128": "icons/icon-128.svg"
-    }
-  },
-  "sidebar_action": {
-    "default_panel": "src/sidepanel/index.html",
-    "default_icon": {
-      "16": "icons/icon-16.svg",
-      "32": "icons/icon-32.svg",
-      "48": "icons/icon-48.svg",
-      "128": "icons/icon-128.svg"
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png",
+      "48": "icons/icon-48.png",
+      "128": "icons/icon-128.png"
     }
   },
   "icons": {
-    "16": "icons/icon-16.svg",
-    "32": "icons/icon-32.svg",
-    "48": "icons/icon-48.svg",
-    "128": "icons/icon-128.svg"
+    "16": "icons/icon-16.png",
+    "32": "icons/icon-32.png",
+    "48": "icons/icon-48.png",
+    "128": "icons/icon-128.png"
   },
   "content_scripts": [
     {
@@ -100,11 +93,11 @@
       "run_at": "document_idle"
     }
   ],
-  "web_accessible_resources": ["assets/*", "icons/*"],
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "defnotpromo@profullstack.com",
-      "strict_min_version": "57.0"
+  "web_accessible_resources": [
+    {
+      "resources": ["assets/*", "icons/*", "src/sidepanel/*"],
+      "matches": ["<all_urls>"]
     }
-  }
+  ]
 }
+

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -12,16 +12,26 @@ const distDir = 'dist';
 // Copy Firefox manifest if building for Firefox
 if (browser === 'firefox') {
   console.log('Copying Firefox-specific manifest...');
-  if (existsSync('public/manifest.firefox.v2.json')) {
-    copyFileSync('public/manifest.firefox.v2.json', join(distDir, 'manifest.firefox.json'));
-    console.log('✓ Firefox Manifest copied to dist/manifest.firefox.json');
+  if (existsSync('public/manifest.firefox.json')) {
+    // Replace manifest.json with Firefox version
+    copyFileSync('public/manifest.firefox.json', join(distDir, 'manifest.json'));
+    console.log('✓ Firefox manifest copied to dist/manifest.json');
+    
+    // Also keep a copy as manifest.firefox.json
+    copyFileSync('public/manifest.firefox.json', join(distDir, 'manifest.firefox.json'));
+    console.log('✓ Firefox manifest copied to dist/manifest.firefox.json');
   }
-  
-  // Remove the v2 file if it was copied by Vite
-  const v2Path = join(distDir, 'manifest.firefox.v2.json');
-  if (existsSync(v2Path)) {
-    unlinkSync(v2Path);
-    console.log('✓ Removed dist/manifest.firefox.v2.json');
+}
+
+// Copy Safari manifest if building for Safari
+if (browser === 'safari') {
+  console.log('Copying Safari-specific manifest...');
+  if (existsSync('public/manifest.safari.json')) {
+    copyFileSync('public/manifest.safari.json', join(distDir, 'manifest.json'));
+    console.log('✓ Safari manifest copied to dist/manifest.json');
+    
+    copyFileSync('public/manifest.safari.json', join(distDir, 'manifest.safari.json'));
+    console.log('✓ Safari manifest copied to dist/manifest.safari.json');
   }
 }
 
@@ -33,8 +43,15 @@ if (browser === 'firefox') {
   console.log('To test in Firefox:');
   console.log('1. Go to about:debugging#/runtime/this-firefox');
   console.log('2. Click "Load Temporary Add-on"');
-  console.log(`3. Select ${distDir}/manifest.firefox.json`);
-  console.log('\nNote: Firefox does not yet support Manifest V3');
+  console.log(`3. Select ANY manifest file in ${distDir}/ folder`);
+  console.log('\n⚠️  NOTE: dist/manifest.json is now Manifest V2 for Firefox');
+  console.log('⚠️  To use Chrome again, rebuild with: pnpm build or pnpm build:chrome');
+} else if (browser === 'safari') {
+  console.log('\n📦 Safari Build Ready!');
+  console.log('To build Safari app:');
+  console.log('1. Run: xcrun safari-web-extension-converter dist/');
+  console.log('2. Open generated Xcode project');
+  console.log('3. Build and run');
 } else {
   console.log('\n📦 Chrome/Edge Build Ready!');
   console.log('To test in Chrome/Edge:');

--- a/src/popup/index.jsx
+++ b/src/popup/index.jsx
@@ -3,13 +3,21 @@ import { createRoot } from 'react-dom/client';
 import '../styles/global.css';
 
 const Popup = () => {
+  const isSafari = () => {
+    return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  };
+
   const openSidePanel = async () => {
     try {
-      // Get current window ID
-      const currentWindow = await chrome.windows.getCurrent();
-      
-      if (chrome.sidePanel && chrome.sidePanel.open) {
+      if (isSafari()) {
+        // Safari: Open sidepanel in new tab
+        chrome.tabs.create({
+          url: chrome.runtime.getURL('src/sidepanel/index.html')
+        });
+        window.close();
+      } else if (chrome.sidePanel && chrome.sidePanel.open) {
         // Chrome/Edge with sidePanel API
+        const currentWindow = await chrome.windows.getCurrent();
         await chrome.sidePanel.open({ windowId: currentWindow.id });
         window.close();
       } else {


### PR DESCRIPTION
Chrome, Firefox, and Safari require different manifest formats and APIs. This commit implements browser-specific build targets to ensure proper compatibility.

## Changes

### Manifest Formats
- **Chrome/Edge**: Manifest V3 with service_worker background script
- **Firefox**: Manifest V2 with scripts array (V3 support experimental/broken)
- **Safari**: Manifest V3 without unsupported APIs (sidePanel)

### Build System
- Updated post-build script to handle browser-specific manifests
- Firefox build now overwrites dist/manifest.json with V2 format
- Added build:safari command for Safari extension conversion
- Added safari-build/ to .gitignore

### Popup Compatibility
- Added Safari detection via user agent
- Safari opens sidepanel in new tab (no native sidePanel API)
- Chrome/Edge use sidePanel.open()
- Firefox sends message to background script for sidebar

### Why Rebuild Per Browser?
Each browser has incompatible extension APIs:

1. **Background Scripts**
   - Chrome V3: service_worker with type: module
   - Firefox V2: scripts array (MV3 service_worker disabled)
   - Safari: service_worker without type: module

2. **Side Panel/Sidebar**
   - Chrome: sidePanel API + side_panel permission
   - Firefox: sidebar_action (different API)
   - Safari: No native support, uses tabs.create()

3. **Permissions**
   - Firefox V2: Combined permissions array
   - Chrome/Safari V3: Separate permissions + host_permissions

4. **Icon Format**
   - Firefox: SVG icons supported
   - Safari: PNG icons required

Building for one browser overwrites dist/manifest.json with that browser's format. To switch browsers, rebuild with the appropriate target:
- pnpm build:chrome
- pnpm build:firefox
- pnpm build:safari