### PR TITLE
feat: implement injected sidebar for Safari and improve Firefox sidebar

### DIFF
--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -51,6 +51,12 @@
   },
   "content_scripts": [
     {
+      "matches": ["<all_urls>"],
+      "js": ["content/content-sidebar-injector.js"],
+      "run_at": "document_idle",
+      "all_frames": false
+    },
+    {
       "matches": ["https://twitter.com/*", "https://x.com/*"],
       "js": ["content/content-twitter.js"],
       "run_at": "document_idle"
@@ -101,7 +107,7 @@
       "run_at": "document_idle"
     }
   ],
-  "web_accessible_resources": ["assets/*", "icons/*"],
+  "web_accessible_resources": ["assets/*", "icons/*", "src/sidebar/*"],
   "browser_specific_settings": {
     "gecko": {
       "id": "defpromo@profullstack.com",

--- a/public/manifest.safari.json
+++ b/public/manifest.safari.json
@@ -11,18 +11,7 @@
     "tabs"
   ],
   "host_permissions": [
-    "https://twitter.com/*",
-    "https://x.com/*",
-    "https://www.linkedin.com/*",
-    "https://www.reddit.com/*",
-    "https://www.facebook.com/*",
-    "https://stacker.news/*",
-    "https://bsky.app/*",
-    "https://*.bsky.social/*",
-    "https://primal.net/*",
-    "https://*.slack.com/*",
-    "https://discord.com/*",
-    "https://web.telegram.org/*"
+    "<all_urls>"
   ],
   "background": {
     "service_worker": "background/service-worker.js"
@@ -43,6 +32,12 @@
     "128": "icons/icon-128.png"
   },
   "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/content-sidebar-injector.js"],
+      "run_at": "document_idle",
+      "all_frames": false
+    },
     {
       "matches": ["https://twitter.com/*", "https://x.com/*"],
       "js": ["content/content-twitter.js"],
@@ -96,7 +91,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["assets/*", "icons/*", "src/sidepanel/*"],
+      "resources": ["assets/*", "icons/*", "src/sidebar/*", "src/sidepanel/*"],
       "matches": ["<all_urls>"]
     }
   ]

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 import { copyFileSync, mkdirSync, readdirSync } from 'fs';
 
 export default defineConfig({
+  publicDir: false, // Disable automatic public directory copying
   plugins: [
     react(),
     {


### PR DESCRIPTION
- Safari now injects sidebar into current page instead of opening new tab
- Sidebar slides in from right with Shadow DOM isolation
- Falls back to new tab if content script unavailable (CSP restrictions)
- Firefox now properly uses native sidebar_action API
- Both browsers inject sidebar-injector content script on all URLs
- Safari manifest requests <all_urls> permission for sidebar injection
- Fixed build process to prevent duplicate manifest files in dist folders
- Added publicDir: false to vite.config to disable automatic public copying